### PR TITLE
Add initial fetch to retrieve weather data on page load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,24 @@
 import React from 'react';
+import { useEffect } from 'react';
+import { getWeather } from './apiCalls';
 
 const App = () => {
+
+  useEffect(() => {
+    loadWeather();
+    return () => {};
+  }, []);
+
+  const loadWeather = async () => {
+    try {
+      const weatherData = await getWeather('San Diego');
+      console.log(weatherData);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+
   return (
     <h1 className="text-3xl font-bold underline">
       ClimaCast

--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -1,0 +1,10 @@
+export const getWeather = async (city: string) => {
+    const response = await fetch(
+      `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${process.env.REACT_APP_WEATHER_API_KEY}`
+    );
+    if (!response.ok) {
+      throw new Error('Failed to get weather data');
+    }
+    const weatherData = await response.json();
+    return weatherData;
+}


### PR DESCRIPTION
## Description
Add logic to load initial weather data on page load.  Currently it's setup to load San Diego's weather.  To test this, you will need to get an API key from the [Open Weather API](https://openweathermap.org/).

## Next Steps
- Add a PR template to create more structure for future PRs.
- Create a form/input to query data more specifically.
- Display important pieces of data for the current day.